### PR TITLE
Add auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,10 @@
 version: 2
 jobs:
   build:
-    only:
-      - master
-      - publish
+    branches:
+      only:
+        - master
+        - publish
     working_directory: /app/homebrew-monitor-rest
     docker:
       - image: node:7.10.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-name: auth
-serviceColor: green
+name: rest
+serviceColor: blue
 morgan:
   format: ':method :status :url - :response-time ms'

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,6 @@
 name: rest
 serviceColor: blue
+authServiceHost: localhost
+authServicePort: 8081
 morgan:
   format: ':method :status :url - :response-time ms'

--- a/index.js
+++ b/index.js
@@ -14,8 +14,7 @@ const {
 	serviceBindIp='0.0.0.0',
 	servicePort=8082,
 	serviceRoot=`/${name}`,
-	serviceSecret='J50NW3bT0k3n',
-	tokenLifetimeH=1,
+	authRoute='/auth',
 	morgan: {
 		format
 	}
@@ -27,14 +26,10 @@ const {
 	SERVICE_PORT:port=servicePort,
 	SERVICE_ROOT:root=serviceRoot,
 	SERVICE_COLOR:color=serviceColor,
-	
-	SERVICE_SECRET:secret=serviceSecret,
-	TOKEN_LIFETIME_H:lifetime=tokenLifetimeH,
 
-	NODE_ENV:environment=serviceEnv,
+	AUTH_ROUTE=authRoute,
 
-	BREW_MASTER:master='admin',
-	BREW_MASTER_PASS:pass='password'
+	NODE_ENV:environment=serviceEnv
 } = process.env
 
 // Do we log?
@@ -53,6 +48,9 @@ silent || app.use(morgan(`${ !color ? name : chalk[color](name)} > ${format}`))
 
 // use common middlewares
 app.use(middleware)
+
+
+
 // register error handler
 app.use(errorHandler)
 
@@ -71,6 +69,6 @@ module.exports = {
     })
   }),
 	// export parsed config for use in tests
-	config: { name, format, ip, port, root, color, master, pass, secret, lifetime }
+	config: { name, format, ip, port, root, color, authRoute, }
 }
 

--- a/index.js
+++ b/index.js
@@ -43,8 +43,13 @@ const authEndpoint = `http://${authHost}:${authPort}${authRoot}`
 // Do we log?
 const silent = (environment === 'Test')
 
-// TODO: move this to module
-const { middleware, errorHandler } = require('homebrew-monitor-common')({name,color,environment})
+const { 
+	notFoundHandler,
+  errorForwardHandler,
+  errorHandler,
+  authHandler,
+  healthHandler 
+} = require('homebrew-monitor-common')({name,color,environment, authEndpoint})
 const {
 	temperature
 } = require('./routes')
@@ -57,13 +62,18 @@ app.use(jsonParser())
 // use morgan unless testing
 silent || app.use(morgan(`${ !color ? name : chalk[color](name)} > ${format}`))
 
+app.use('/health', healthHandler)
+
+// register AUTH middleware
+app.use(authHandler)
+
+/* -- Begin Authenticated routes */
 // register REST routes
 app.use('/temperature', temperature)
 
-// use common middlewares
-app.use(middleware)
-
-// register error handler
+// use common middlewares for error handling
+app.use(notFoundHandler)
+app.use(errorForwardHandler)
 app.use(errorHandler)
 
 // set base route

--- a/index.js
+++ b/index.js
@@ -14,7 +14,11 @@ const {
 	serviceBindIp='0.0.0.0',
 	servicePort=8082,
 	serviceRoot=`/${name}`,
-	authRoute='/auth',
+	
+	authServiceRoot='/auth',
+	authServiceHost=serviceBindIp,
+	authServicePort=servicePort,
+	
 	morgan: {
 		format
 	}
@@ -27,16 +31,23 @@ const {
 	SERVICE_ROOT:root=serviceRoot,
 	SERVICE_COLOR:color=serviceColor,
 
-	AUTH_ROUTE=authRoute,
+	AUTH_ROUTE:authRoot=authServiceRoot,
+	AUTH_HOST:authHost=authServiceHost,
+	AUTH_PORT:authPort=authServicePort,
 
 	NODE_ENV:environment=serviceEnv
 } = process.env
 
+// Create endpoint for auth service
+const authEndpoint = `http://${authHost}:${authPort}${authRoot}`
 // Do we log?
 const silent = (environment === 'Test')
 
 // TODO: move this to module
 const { middleware, errorHandler } = require('homebrew-monitor-common')({name,color,environment})
+const {
+	temperature
+} = require('./routes')
 const base = express()
 const app = express()
 
@@ -46,10 +57,11 @@ app.use(jsonParser())
 // use morgan unless testing
 silent || app.use(morgan(`${ !color ? name : chalk[color](name)} > ${format}`))
 
+// register REST routes
+app.use('/temperature', temperature)
+
 // use common middlewares
 app.use(middleware)
-
-
 
 // register error handler
 app.use(errorHandler)
@@ -69,6 +81,6 @@ module.exports = {
     })
   }),
 	// export parsed config for use in tests
-	config: { name, format, ip, port, root, color, authRoute, }
+	config: { name, format, ip, port, root, color, authEndpoint }
 }
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const { json: jsonParser } = require('body-parser-json')
 // load service config
 const {
 	name='service',
-	serviceEnv='Test',
+	serviceEnv='Production',
 	serviceColor=false,
 	serviceBindIp='0.0.0.0',
 	servicePort=8082,
@@ -23,7 +23,6 @@ const {
 
 // load ENV
 const {
-	SERVICE_ENV:environment=serviceEnv,
 	SERVICE_BIND_IP:ip=serviceBindIp,
 	SERVICE_PORT:port=servicePort,
 	SERVICE_ROOT:root=serviceRoot,
@@ -31,7 +30,9 @@ const {
 	
 	SERVICE_SECRET:secret=serviceSecret,
 	TOKEN_LIFETIME_H:lifetime=tokenLifetimeH,
-	
+
+	NODE_ENV:environment=serviceEnv,
+
 	BREW_MASTER:master='admin',
 	BREW_MASTER_PASS:pass='password'
 } = process.env

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   },
   "devDependencies": {
     "mocha": "^3.3.0",
-    "should": "^11.2.1",
+    "nock": "^9.0.13",
     "request": "^2.81.0",
-    "request-promise": "^4.2.0"
+    "request-promise": "^4.2.0",
+    "should": "^11.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "start": "node index.js"
+    "start": "node index.js",
+    "docker-build-test": "docker build -t homebrew-monitor-rest-test -f Dockerfile.test .",
+    "docker-run-test": "docker run -it --rm homebrew-monitor-rest-test",
+    "docker-build": "docker build -t homebrew-monitor-rest -f Dockerfile.production .",
+    "docker-run": "docker run -it --rm homebrew-monitor-rest"
   },
   "author": "",
   "license": "ISC",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  temperature: require('./temperature')
+}

--- a/routes/temperature.js
+++ b/routes/temperature.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 router.get('/', function getTempurature(req, res, next) {
-  res.status(200).send({
+  return res.status(200).send({
     // stubbed, return integer between 0 and 120
     temperature: Math.random() * 120
   })

--- a/routes/temperature.js
+++ b/routes/temperature.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', function getTempurature(req, res, next) {
+  res.status(200).send({
+    // stubbed, return integer between 0 and 120
+    temperature: Math.random() * 120
+  })
+});
+
+module.exports = router;

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ const nock = require('nock')
 process.env['NODE_ENV'] = 'Test'
 
 // start app server
-const { service, config: {port, root, authRoute} } = require('../index')
+const { service, config: {port, root, authEndpoint} } = require('../index')
 const base = `http://localhost:${port}${root}`
 
 // state object enclosing properties to override test closures
@@ -53,14 +53,14 @@ describe('Health', function describeHealth() {
 describe('Authentication', function describeAuth() {
   it('should permit requests with a valid jwt', function validToken () {
     // mock the api of the auth microservice
-    nock(base)
-      .get(`/${authRoute}/decode`)
+    nock(authEndpoint)
+      .get(`/decode`)
       .reply(200, {
         username: "AUser"
       })
 
     return rp({
-      uri: `${base}/aTestRoute`, // TODO: create a route to use
+      uri: `${base}/temperature`, // TODO: create a route to use
       headers: {
         auth: 'Bearer PretendRealToken'
       },
@@ -73,14 +73,14 @@ describe('Authentication', function describeAuth() {
 
   it('should reject requests with an invalid jwt', function validToken () {
     // mock the api of the auth microservice
-    nock(base)
-      .get(`/${authRoute}/decode`)
+    nock(authEndpoint)
+      .get(`/decode`)
       .reply(401, {
         message: 'Invalid credentials'
       })
 
     return rp({
-      uri: `${base}/aTestRoute`, // TODO: create a route to use
+      uri: `${base}/temperature`, // TODO: create a route to use
       headers: {
         auth: 'Bearer PretendBadToken'
       },


### PR DESCRIPTION
# Stubbed basic API and added authentication
- Mocking microservice interaction with Nock
- Using newer common module with individually exported handlers
- Using common auth handler to authenticate all requests with a Bearer header and JWT